### PR TITLE
Update tree-sitter-haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ A [Haskell](https://www.haskell.org/) extension for [Zed](https://zed.dev).
 ## Development
 
 To develop this extension, see the [Developing Extensions](https://zed.dev/docs/extensions/developing-extensions) section of the Zed docs.
+
+### Update grammar/queries
+
+1. Bump commit in `extension.toml` to a commit in `tree-sitter/tree-sitter-haskell`
+2. Run `scripts/download_hs_queries.py` with a commit in `tek/tree-sitter-haskell`
+
+`tek/tree-sitter-haskell` is more up-to-date than `tree-sitter/tree-sitter-haskell`, so ideally, we'd switch to it ([issue](https://github.com/tek/tree-sitter-haskell/issues/11)). However, `tek/tree-sitter-haskell` doesn't commit `parser.c`, which Zed depends on ([issue](https://github.com/zed-industries/zed/discussions/52532)). Furthermore, regenerating `parser.c` and pointing the extension to it causes Zed to freeze ([issue](https://github.com/zed-industries/zed/issues/52535)). So for now, we'll use `tree-sitter/tree-sitter-haskell` for the grammar, but `tek/tree-sitter-haskell` for the queries.

--- a/extension.toml
+++ b/extension.toml
@@ -18,8 +18,19 @@ languages = [
 ]
 
 [grammars.haskell]
+# tek/tree-sitter-haskell is more up-to-date than tree-sitter/tree-sitter-haskell,
+# so ideally, we'd switch to it [1]. However, it doesn't commit parser.c, which
+# Zed depends on [2]. Furthermore, regenerating parser.c and pointing the
+# extension to it causes Zed to freeze [3]. So for now, we'll use
+# tree-sitter/tree-sitter-haskell for the grammar, but tek/tree-sitter-haskell
+# for the queries.
+#
+# References:
+# [1]: https://github.com/tek/tree-sitter-haskell/issues/11
+# [2]: https://github.com/zed-industries/zed/issues/52535
+# [3]: https://github.com/zed-industries/zed/discussions/52532
 repository = "https://github.com/tree-sitter/tree-sitter-haskell"
-commit = "8a99848fc734f9c4ea523b3f2a07df133cbbcec2"
+commit = "c30d812bc90827f1a54106a25bc9a6307f5cdcec" # 0.23.1
 
 [grammars.cabal]
 repository = "https://gitlab.com/zweimach/tree-sitter-cabal/"

--- a/extension.toml
+++ b/extension.toml
@@ -18,17 +18,6 @@ languages = [
 ]
 
 [grammars.haskell]
-# tek/tree-sitter-haskell is more up-to-date than tree-sitter/tree-sitter-haskell,
-# so ideally, we'd switch to it [1]. However, it doesn't commit parser.c, which
-# Zed depends on [2]. Furthermore, regenerating parser.c and pointing the
-# extension to it causes Zed to freeze [3]. So for now, we'll use
-# tree-sitter/tree-sitter-haskell for the grammar, but tek/tree-sitter-haskell
-# for the queries.
-#
-# References:
-# [1]: https://github.com/tek/tree-sitter-haskell/issues/11
-# [2]: https://github.com/zed-industries/zed/issues/52535
-# [3]: https://github.com/zed-industries/zed/discussions/52532
 repository = "https://github.com/tree-sitter/tree-sitter-haskell"
 commit = "c30d812bc90827f1a54106a25bc9a6307f5cdcec" # 0.23.1
 

--- a/languages/haskell/highlights.scm
+++ b/languages/haskell/highlights.scm
@@ -156,7 +156,7 @@
   type: (type))
 
 ((decl/signature
-  name: (variable) @_name @variable.x
+  name: (variable) @_name
   type: (type))
   .
   (decl
@@ -179,7 +179,7 @@
   (#eq? @_type "IO"))
 
 ((decl/signature
-  name: (variable) @_name @function.x
+  name: (variable) @_name
   type: (type/apply
     constructor: (name) @_type)
   (#eq? @_type "IO"))
@@ -263,8 +263,8 @@
     (variable) @function.call)
 ]
   .
-  (operator) @operator
-  (#any-of? @operator "$" "<$>" ">>=" "=<<"))
+  (operator) @_op
+  (#any-of? @_op "$" "<$>" ">>=" "=<<"))
 
 ; right hand side of infix operator
 ((infix
@@ -280,8 +280,8 @@
       (variable) @function.call)
   ])
   .
-  (operator) @operator
-  (#any-of? @operator "$" "<$>" "=<<"))
+  (operator) @_op
+  (#any-of? @_op "$" "<$>" "=<<"))
 
 ; decl/function composition, arrows, monadic composition (lhs)
 ([
@@ -290,8 +290,8 @@
     (variable) @function)
 ]
   .
-  (operator) @operator
-  (#any-of? @operator "." ">>>" "***" ">=>" "<=<"))
+  (operator) @_op
+  (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))
 
 ; right hand side of infix operator
 ((infix
@@ -307,26 +307,26 @@
       (variable) @function)
   ])
   .
-  (operator) @operator
-  (#any-of? @operator "." ">>>" "***" ">=>" "<=<"))
+  (operator) @_op
+  (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))
 
 ; function composition, arrows, monadic composition (rhs)
-((operator) @operator
+((operator) @_op
   .
   [
     (expression/variable) @function
     (expression/qualified
       (variable) @function)
   ]
-  (#any-of? @operator "." ">>>" "***" ">=>" "<=<"))
+  (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))
 
 ; function defined in terms of a function composition
 (decl/function
   name: (variable) @function
   (match
     expression: (infix
-      operator: (operator) @operator
-      (#any-of? @operator "." ">>>" "***" ">=>" "<=<"))))
+      operator: (operator) @_op
+      (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))))
 
 (apply
   [
@@ -390,7 +390,7 @@
   type: (function))
 
 ((decl/signature
-  name: (variable) @_name @function.x
+  name: (variable) @_name
   type: (quantified_type))
   .
   (decl/bind
@@ -408,8 +408,8 @@
   name: (variable) @function
   match: (match
     expression: (infix
-      operator: (operator) @operator
-      (#eq? @operator "."))))
+      operator: (operator) @_op
+      (#eq? @_op "."))))
 
 ; ----------------------------------------------------------------------------
 ; Types

--- a/languages/haskell/highlights.scm
+++ b/languages/haskell/highlights.scm
@@ -1,32 +1,41 @@
-; Copyright 2022 nvim-treesitter
+; ----------------------------------------------------------------------------
+; Copied from:
+; https://raw.githubusercontent.com/tek/tree-sitter-haskell/12b8cb96fbdca77dfabbdf71dc5ce8f879df32d0/queries/highlights.scm
 ;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
+; ----------------------------------------------------------------------------
+; Parameters and variables
+; NOTE: These are at the top, so that they have low priority,
+; and don't override destructured parameters
+(variable) @variable
+
+(decl/function
+  patterns: (patterns
+    (_) @variable.parameter))
+
+(expression/lambda
+  (_)+ @variable.parameter
+  "->")
+
+(decl/function
+  (infix
+    (pattern) @variable.parameter))
+
 ; ----------------------------------------------------------------------------
 ; Literals and comments
 (integer) @number
 
-(exp_negation) @number
+(negation) @number
 
-(exp_literal
-  (float)) @float
+(expression/literal
+  (float)) @number.float
 
-(char) @string
+(char) @character
 
 (string) @string
 
-(con_unit) @symbol ; unit, as in ()
-
 (comment) @comment
+
+(haddock) @comment.documentation
 
 ; ----------------------------------------------------------------------------
 ; Punctuation
@@ -40,7 +49,7 @@
 ] @punctuation.bracket
 
 [
-  (comma)
+  ","
   ";"
 ] @punctuation.delimiter
 
@@ -48,10 +57,10 @@
 ; Keywords, operators, includes
 [
   "forall"
-  "∀"
-] @keyword
+  ; "∀" ; utf-8 is not cross-platform safe
+] @keyword.repeat
 
-(pragma) @constant
+(pragma) @keyword.directive
 
 [
   "if"
@@ -59,26 +68,20 @@
   "else"
   "case"
   "of"
-] @keyword
-
-(exp_lambda_cases
-  "\\"
-  "cases" @variant)
+] @keyword.conditional
 
 [
   "import"
   "qualified"
   "module"
-] @keyword
+] @keyword.import
 
 [
   (operator)
   (constructor_operator)
-  (type_operator)
-  (tycon_arrow)
-  (qualified_module) ; grabs the `.` (dot), ex: import System.IO
   (all_names)
-  (wildcard)
+  "."
+  ".."
   "="
   "|"
   "::"
@@ -90,14 +93,18 @@
   "@"
 ] @operator
 
-(module) @title
+(wildcard) @character.special
+
+(module
+  (module_id) @module)
 
 [
-  (where)
+  "where"
   "let"
   "in"
   "class"
   "instance"
+  "pattern"
   "data"
   "newtype"
   "family"
@@ -118,70 +125,375 @@
 
 ; ----------------------------------------------------------------------------
 ; Functions and variables
-(variable) @variable
+(decl/signature
+  [
+    name: (variable) @function
+    names: (binding_list
+      (variable) @function)
+  ])
 
-(pat_wildcard) @variable
+(decl/function
+  [
+    name: (variable) @function
+    names: (binding_list
+      (variable) @function)
+  ])
 
-(signature
-  name: (variable) @type)
+(decl/bind
+  [
+    name: (variable) @function
+    names: (binding_list
+      (variable) @function)
+  ])
 
-(function
+(decl/bind
+  name: (variable) @variable)
+
+; Consider signatures (and accompanying functions)
+; with only one value on the rhs as variables
+(decl/signature
+  name: (variable) @variable
+  type: (type))
+
+((decl/signature
+  name: (variable) @_name
+  type: (type))
+  .
+  (decl
+    [
+      (signature
+        name: (variable) @variable)
+      (function
+        name: (variable) @variable)
+      (bind
+        name: (variable) @variable)
+    ])
+  match: (_)
+  (#eq? @_name @variable))
+
+; but consider a type that involves 'IO' a decl/function
+(decl/signature
   name: (variable) @function
-  patterns: (patterns))
+  type: (type/apply
+    constructor: (name) @_type)
+  (#eq? @_type "IO"))
 
-((signature
-  (fun))
+((decl/signature
+  name: (variable) @_name
+  type: (type/apply
+    constructor: (name) @_type)
+  (#eq? @_type "IO"))
   .
-  (function
-    (variable) @function))
+  (decl
+    [
+      (signature
+        name: (variable) @function)
+      (function
+        name: (variable) @function)
+      (bind
+        name: (variable) @function)
+    ])
+  match: (_)
+  (#eq? @_name @function))
 
-((signature
-  (context
-    (fun)))
+((decl/signature) @function
   .
-  (function
-    (variable) @function))
+  (decl/function
+    name: (variable) @function))
 
-((signature
-  (forall
-    (context
-      (fun))))
+(decl/bind
+  name: (variable) @function
+  (match
+    expression: (expression/lambda)))
+
+; view patterns
+(view_pattern
+  [
+    (expression/variable) @function.call
+    (expression/qualified
+      (variable) @function.call)
+  ])
+
+; consider infix functions as operators
+(infix_id
+  [
+    (variable) @operator
+    (qualified
+      (variable) @operator)
+  ])
+
+; decl/function calls with an infix operator
+; e.g. func <$> a <*> b
+(infix
+  left_operand: [
+    (variable) @function.call
+    (qualified
+      ((module) @module
+        (variable) @function.call))
+  ])
+
+; infix operators applied to variables
+((expression/variable) @variable
   .
-  (function
-    (variable) @function))
+  (operator))
 
-(exp_infix
-  (variable) @operator) ; consider infix functions as operators
-
-(exp_infix
-  (exp_name) @function
-  (#set! "priority" 101))
-
-(exp_apply
+((operator)
   .
-  (exp_name
-    (variable) @function))
+  [
+    (expression/variable) @variable
+    (expression/qualified
+      (variable) @variable)
+  ])
 
-(exp_apply
+; infix operator function definitions
+(function
+  (infix
+    left_operand: [
+      (variable) @variable
+      (qualified
+        ((module) @module
+          (variable) @variable))
+    ])
+  match: (match))
+
+; decl/function calls with infix operators
+([
+  (expression/variable) @function.call
+  (expression/qualified
+    (variable) @function.call)
+]
   .
-  (exp_name
-    (qualified_variable
-      (variable) @function)))
+  (operator) @_op
+  (#any-of? @_op "$" "<$>" ">>=" "=<<"))
+
+; right hand side of infix operator
+((infix
+  [
+    (operator)
+    (infix_id
+      (variable))
+  ] ; infix or `func`
+  .
+  [
+    (variable) @function.call
+    (qualified
+      (variable) @function.call)
+  ])
+  .
+  (operator) @_op
+  (#any-of? @_op "$" "<$>" "=<<"))
+
+; decl/function composition, arrows, monadic composition (lhs)
+([
+  (expression/variable) @function
+  (expression/qualified
+    (variable) @function)
+]
+  .
+  (operator) @_op
+  (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))
+
+; right hand side of infix operator
+((infix
+  [
+    (operator)
+    (infix_id
+      (variable))
+  ] ; infix or `func`
+  .
+  [
+    (variable) @function
+    (qualified
+      (variable) @function)
+  ])
+  .
+  (operator) @_op
+  (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))
+
+; function composition, arrows, monadic composition (rhs)
+((operator) @_op
+  .
+  [
+    (expression/variable) @function
+    (expression/qualified
+      (variable) @function)
+  ]
+  (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))
+
+; function defined in terms of a function composition
+(decl/function
+  name: (variable) @function
+  (match
+    expression: (infix
+      operator: (operator) @_op
+      (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))))
+
+(apply
+  [
+    (expression/variable) @function.call
+    (expression/qualified
+      (variable) @function.call)
+  ])
+
+; function compositions, in parentheses, applied
+; lhs
+(apply
+  .
+  (expression/parens
+    (infix
+      [
+        (variable) @function.call
+        (qualified
+          (variable) @function.call)
+      ]
+      .
+      (operator))))
+
+; rhs
+(apply
+  .
+  (expression/parens
+    (infix
+      (operator)
+      .
+      [
+        (variable) @function.call
+        (qualified
+          (variable) @function.call)
+      ])))
+
+; variables being passed to a function call
+(apply
+  (_)
+  .
+  [
+    (expression/variable) @variable
+    (expression/qualified
+      (variable) @variable)
+  ])
+
+; main is always a function
+; (this prevents `main = undefined` from being highlighted as a variable)
+(decl/bind
+  name: (variable) @function
+  (#eq? @function "main"))
+
+; scoped function types (func :: a -> b)
+(signature
+  pattern: (pattern/variable) @function
+  type: (function))
+
+; signatures that have a function type
+; + binds that follow them
+(decl/signature
+  name: (variable) @function
+  type: (function))
+
+((decl/signature
+  name: (variable) @_name
+  type: (quantified_type))
+  .
+  (decl/bind
+    (variable) @function)
+  (#eq? @function @_name))
+
+; Treat constructor assignments (smart constructors) as functions, e.g. mkJust = Just
+(bind
+  name: (variable) @function
+  match: (match
+    expression: (constructor)))
+
+; Function composition
+(bind
+  name: (variable) @function
+  match: (match
+    expression: (infix
+      operator: (operator) @_op
+      (#eq? @_op "."))))
 
 ; ----------------------------------------------------------------------------
 ; Types
-(type) @type
+(name) @type
 
-(type_variable) @type
+(type/unit) @type
+
+(type/unit
+  [
+    "("
+    ")"
+  ] @type)
+
+(type/list
+  [
+    "["
+    "]"
+  ] @type)
+
+(type/star) @type
 
 (constructor) @constructor
 
 ; True or False
-((constructor) @_bool
-  (#match? @_bool "(True|False)")) @boolean
+((constructor) @boolean
+  (#any-of? @boolean "True" "False"))
+
+; otherwise (= True)
+((variable) @boolean
+  (#eq? @boolean "otherwise"))
 
 ; ----------------------------------------------------------------------------
 ; Quasi-quotes
-(quoter) @function
+(quoter) @function.call
 
-; Highlighting of quasiquote_body is handled by injections.scm
+(quasiquote
+  quoter: [
+    (quoter) @_name
+    (quoter
+      (qualified
+        id: (variable) @_name))
+  ]
+  (#eq? @_name "qq")
+  body: (quasiquote_body) @string)
+
+; namespaced quasi-quoter
+(quoter
+  [
+    (variable) @function.call
+    (_
+      (module) @module
+      .
+      (variable) @function.call)
+  ])
+
+; Highlighting of quasiquote_body for other languages is handled by injections.scm
+; ----------------------------------------------------------------------------
+; Exceptions/error handling
+((variable) @keyword.exception
+  (#any-of? @keyword.exception
+    "error" "undefined" "try" "tryJust" "tryAny" "catch" "catches" "catchJust" "handle" "handleJust"
+    "throw" "throwIO" "throwTo" "throwError" "ioError" "mask" "mask_" "uninterruptibleMask"
+    "uninterruptibleMask_" "bracket" "bracket_" "bracketOnErrorSource" "finally" "fail"
+    "onException" "expectationFailure"))
+
+; ----------------------------------------------------------------------------
+; Debugging
+((variable) @keyword.debug
+  (#any-of? @keyword.debug
+    "trace" "traceId" "traceShow" "traceShowId" "traceWith" "traceShowWith" "traceStack" "traceIO"
+    "traceM" "traceShowM" "traceEvent" "traceEventWith" "traceEventIO" "flushEventLog" "traceMarker"
+    "traceMarkerIO"))
+
+; ----------------------------------------------------------------------------
+; Fields
+(field_name
+  (variable) @variable.member)
+
+(import_name
+  (name)
+  .
+  (children
+    (variable) @variable.member))
+
+; ----------------------------------------------------------------------------
+; Spell checking
+(comment) @spell

--- a/languages/haskell/highlights.scm
+++ b/languages/haskell/highlights.scm
@@ -1,6 +1,6 @@
-; ----------------------------------------------------------------------------
-; Copied from:
-; https://raw.githubusercontent.com/tek/tree-sitter-haskell/12b8cb96fbdca77dfabbdf71dc5ce8f879df32d0/queries/highlights.scm
+; ------------------------------------------------------------------------------
+; Adapted from https://raw.githubusercontent.com/tek/tree-sitter-haskell/12b8cb96fbdca77dfabbdf71dc5ce8f879df32d0
+; See scripts/download_hs_queries.py
 ;
 ; ----------------------------------------------------------------------------
 ; Parameters and variables
@@ -29,7 +29,7 @@
 (expression/literal
   (float)) @number.float
 
-(char) @character
+(char) @string
 
 (string) @string
 
@@ -93,10 +93,10 @@
   "@"
 ] @operator
 
-(wildcard) @character.special
+(wildcard) @string.special
 
 (module
-  (module_id) @module)
+  (module_id) @title)
 
 [
   "where"
@@ -156,7 +156,7 @@
   type: (type))
 
 ((decl/signature
-  name: (variable) @_name
+  name: (variable) @_name @variable.x
   type: (type))
   .
   (decl
@@ -179,7 +179,7 @@
   (#eq? @_type "IO"))
 
 ((decl/signature
-  name: (variable) @_name
+  name: (variable) @_name @function.x
   type: (type/apply
     constructor: (name) @_type)
   (#eq? @_type "IO"))
@@ -228,7 +228,7 @@
   left_operand: [
     (variable) @function.call
     (qualified
-      ((module) @module
+      ((module) @title
         (variable) @function.call))
   ])
 
@@ -251,7 +251,7 @@
     left_operand: [
       (variable) @variable
       (qualified
-        ((module) @module
+        ((module) @title
           (variable) @variable))
     ])
   match: (match))
@@ -263,8 +263,8 @@
     (variable) @function.call)
 ]
   .
-  (operator) @_op
-  (#any-of? @_op "$" "<$>" ">>=" "=<<"))
+  (operator) @operator
+  (#any-of? @operator "$" "<$>" ">>=" "=<<"))
 
 ; right hand side of infix operator
 ((infix
@@ -280,8 +280,8 @@
       (variable) @function.call)
   ])
   .
-  (operator) @_op
-  (#any-of? @_op "$" "<$>" "=<<"))
+  (operator) @operator
+  (#any-of? @operator "$" "<$>" "=<<"))
 
 ; decl/function composition, arrows, monadic composition (lhs)
 ([
@@ -290,8 +290,8 @@
     (variable) @function)
 ]
   .
-  (operator) @_op
-  (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))
+  (operator) @operator
+  (#any-of? @operator "." ">>>" "***" ">=>" "<=<"))
 
 ; right hand side of infix operator
 ((infix
@@ -307,26 +307,26 @@
       (variable) @function)
   ])
   .
-  (operator) @_op
-  (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))
+  (operator) @operator
+  (#any-of? @operator "." ">>>" "***" ">=>" "<=<"))
 
 ; function composition, arrows, monadic composition (rhs)
-((operator) @_op
+((operator) @operator
   .
   [
     (expression/variable) @function
     (expression/qualified
       (variable) @function)
   ]
-  (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))
+  (#any-of? @operator "." ">>>" "***" ">=>" "<=<"))
 
 ; function defined in terms of a function composition
 (decl/function
   name: (variable) @function
   (match
     expression: (infix
-      operator: (operator) @_op
-      (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))))
+      operator: (operator) @operator
+      (#any-of? @operator "." ">>>" "***" ">=>" "<=<"))))
 
 (apply
   [
@@ -390,7 +390,7 @@
   type: (function))
 
 ((decl/signature
-  name: (variable) @_name
+  name: (variable) @_name @function.x
   type: (quantified_type))
   .
   (decl/bind
@@ -408,8 +408,8 @@
   name: (variable) @function
   match: (match
     expression: (infix
-      operator: (operator) @_op
-      (#eq? @_op "."))))
+      operator: (operator) @operator
+      (#eq? @operator "."))))
 
 ; ----------------------------------------------------------------------------
 ; Types
@@ -460,7 +460,7 @@
   [
     (variable) @function.call
     (_
-      (module) @module
+      (module) @title
       .
       (variable) @function.call)
   ])
@@ -468,8 +468,8 @@
 ; Highlighting of quasiquote_body for other languages is handled by injections.scm
 ; ----------------------------------------------------------------------------
 ; Exceptions/error handling
-((variable) @keyword.exception
-  (#any-of? @keyword.exception
+((variable) @constant.builtin
+  (#any-of? @constant.builtin
     "error" "undefined" "try" "tryJust" "tryAny" "catch" "catches" "catchJust" "handle" "handleJust"
     "throw" "throwIO" "throwTo" "throwError" "ioError" "mask" "mask_" "uninterruptibleMask"
     "uninterruptibleMask_" "bracket" "bracket_" "bracketOnErrorSource" "finally" "fail"
@@ -477,8 +477,8 @@
 
 ; ----------------------------------------------------------------------------
 ; Debugging
-((variable) @keyword.debug
-  (#any-of? @keyword.debug
+((variable) @constant.builtin
+  (#any-of? @constant.builtin
     "trace" "traceId" "traceShow" "traceShowId" "traceWith" "traceShowWith" "traceStack" "traceIO"
     "traceM" "traceShowM" "traceEvent" "traceEventWith" "traceEventIO" "flushEventLog" "traceMarker"
     "traceMarkerIO"))
@@ -496,4 +496,4 @@
 
 ; ----------------------------------------------------------------------------
 ; Spell checking
-(comment) @spell
+;(comment) @spell

--- a/languages/haskell/injections.scm
+++ b/languages/haskell/injections.scm
@@ -1,6 +1,6 @@
-; ----------------------------------------------------------------------------
-; Copied from:
-; https://raw.githubusercontent.com/tek/tree-sitter-haskell/12b8cb96fbdca77dfabbdf71dc5ce8f879df32d0/queries/highlights.scm
+; ------------------------------------------------------------------------------
+; Adapted from https://raw.githubusercontent.com/tek/tree-sitter-haskell/12b8cb96fbdca77dfabbdf71dc5ce8f879df32d0
+; See scripts/download_hs_queries.py
 ;
 ; -----------------------------------------------------------------------------
 ; General language injection

--- a/languages/haskell/injections.scm
+++ b/languages/haskell/injections.scm
@@ -1,2 +1,80 @@
-((comment) @content
-  (#set! "language" "comment"))
+; ----------------------------------------------------------------------------
+; Copied from:
+; https://raw.githubusercontent.com/tek/tree-sitter-haskell/12b8cb96fbdca77dfabbdf71dc5ce8f879df32d0/queries/highlights.scm
+;
+; -----------------------------------------------------------------------------
+; General language injection
+(quasiquote
+  (quoter) @injection.language
+  (quasiquote_body) @injection.content)
+
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+; -----------------------------------------------------------------------------
+; shakespeare library
+; NOTE: doesn't support templating
+; TODO: add once CoffeeScript parser is added
+; ; CoffeeScript: Text.Coffee
+; (quasiquote
+;  (quoter) @_name
+;  (#eq? @_name "coffee")
+;  ((quasiquote_body) @injection.content
+;   (#set! injection.language "coffeescript")))
+; CSS: Text.Cassius, Text.Lucius
+(quasiquote
+  (quoter) @_name
+  (#any-of? @_name "cassius" "lucius")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "css"))
+
+; HTML: Text.Hamlet
+(quasiquote
+  (quoter) @_name
+  (#any-of? @_name "shamlet" "xshamlet" "hamlet" "xhamlet" "ihamlet")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "html"))
+
+; JS: Text.Julius
+(quasiquote
+  (quoter) @_name
+  (#any-of? @_name "js" "julius")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "javascript"))
+
+; TS: Text.TypeScript
+(quasiquote
+  (quoter) @_name
+  (#any-of? @_name "tsc" "tscJSX")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "typescript"))
+
+; -----------------------------------------------------------------------------
+; HSX
+(quasiquote
+  (quoter) @_name
+  (#eq? @_name "hsx")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "html"))
+
+; -----------------------------------------------------------------------------
+; Inline JSON from aeson
+(quasiquote
+  (quoter) @_name
+  (#eq? @_name "aesonQQ")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "json"))
+
+; -----------------------------------------------------------------------------
+; SQL
+; postgresql-simple
+(quasiquote
+  (quoter) @injection.language
+  (#eq? @injection.language "sql")
+  (quasiquote_body) @injection.content)
+
+(quasiquote
+  (quoter) @_name
+  (#any-of? @_name "persistUpperCase" "persistLowerCase" "persistWith")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "haskell_persistent"))

--- a/languages/haskell/outline.scm
+++ b/languages/haskell/outline.scm
@@ -1,26 +1,26 @@
-(adt
+(data_type
   "data" @context
-  name: (type) @name) @item
+  name: (name) @name) @item
 
-(type_alias
+(type_synomym  ; typo: https://github.com/tree-sitter/tree-sitter-haskell/pull/145
   "type" @context
-  name: (type) @name) @item
+  name: (name) @name) @item
 
 (newtype
   "newtype" @context
-  name: (type) @name) @item
+  name: (name) @name) @item
 
 (signature
   name: (variable) @name) @item
 
 (class
   "class" @context
-  (class_head) @name) @item
+  (name) @name) @item
 
 (instance
   "instance" @context
-  (instance_head) @name) @item
+  (name) @name) @item
 
 (foreign_import
   "foreign" @context
-  (impent) @name) @item
+  (entity) @name) @item

--- a/languages/haskell/outline.scm
+++ b/languages/haskell/outline.scm
@@ -2,7 +2,7 @@
   "data" @context
   name: (name) @name) @item
 
-(type_synomym  ; typo: https://github.com/tree-sitter/tree-sitter-haskell/pull/145
+(type_synomym ; typo: https://github.com/tree-sitter/tree-sitter-haskell/pull/145
   "type" @context
   name: (name) @name) @item
 

--- a/languages/haskell/textobjects.scm
+++ b/languages/haskell/textobjects.scm
@@ -16,4 +16,4 @@
 
 (function
   (match
-      expression: (_) @function.inside))
+    expression: (_) @function.inside))

--- a/languages/haskell/textobjects.scm
+++ b/languages/haskell/textobjects.scm
@@ -1,12 +1,12 @@
 (comment)+ @comment.around
 
 [
-  (adt)
-  (type_alias)
+  (data_type)
+  (type_synomym) ; typo: https://github.com/tree-sitter/tree-sitter-haskell/pull/145
   (newtype)
 ] @class.around
 
-(record_fields
+(fields
   "{"
   (_)* @class.inside
   "}")
@@ -15,4 +15,5 @@
   (function)+) @function.around
 
 (function
-  rhs: (_) @function.inside)
+  (match
+      expression: (_) @function.inside))

--- a/scripts/download_hs_queries.py
+++ b/scripts/download_hs_queries.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import textwrap
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).absolute().parent.parent
+HS_DIR = ROOT_DIR / "languages" / "haskell"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("commit", help="Commit in tek/tree-sitter")
+    args = parser.parse_args()
+
+    gh_base_url = (
+        f"https://raw.githubusercontent.com/tek/tree-sitter-haskell/{args.commit}"
+    )
+    header = "\n".join(
+        [
+            "; ------------------------------------------------------------------------------",
+            f"; Adapted from {gh_base_url}",
+            "; See scripts/download_hs_queries.py",
+            ";",
+            "",
+        ]
+    )
+
+    print("Downloading highlights.scm...")
+    highlights = curl(f"{gh_base_url}/queries/highlights.scm")
+    highlights = update_highlights(highlights)
+    (HS_DIR / "highlights.scm").write_text(header + highlights)
+
+    print("Downloading injections.scm...")
+    injections = curl(f"{gh_base_url}/queries/injections.scm")
+    (HS_DIR / "injections.scm").write_text(header + injections)
+
+
+def update_highlights(s: str) -> str:
+    sig1 = textwrap.dedent("""\
+    (decl/signature
+      name: (variable) @_name
+      type: (type))
+    """)
+    sig2 = textwrap.dedent("""\
+    (decl/signature
+      name: (variable) @_name
+      type: (type/apply
+        constructor: (name) @_type)
+      (#eq? @_type "IO"))
+    """)
+    sig3 = textwrap.dedent("""\
+    (decl/signature
+      name: (variable) @_name
+      type: (quantified_type))
+    """)
+    return (
+        s
+        # Zed doesn't have @character
+        .replace("@character", "@string")
+        # Zed doesn't have @module
+        .replace("@module", "@title")
+        # @keyword makes these variables look like Haskell syntax keywords
+        # instead of just normal built-in functions
+        .replace("@keyword.exception", "@constant.builtin")
+        .replace("@keyword.debug", "@constant.builtin")
+        # @_name is used in some signature highlighting for a local capture,
+        # which overrides the relevant highlighting
+        # We also need to add some arbitrary suffix to avoid clobbering the
+        # scope for (#eq? ...)
+        .replace(sig1, sig1.replace("@_name", "@_name @variable.x"))
+        .replace(sig2, sig2.replace("@_name", "@_name @function.x"))
+        .replace(sig3, sig3.replace("@_name", "@_name @function.x"))
+        # @_op is used as a local capture for predicates, but Zed will actually
+        # override the @operator capture previously set on (operator) nodes.
+        .replace("@_op", "@operator")
+        # @spell isn't valid in Zed and overrides the @comment capture. Comment out
+        # this line.
+        .replace("(comment) @spell", ";(comment) @spell")
+    )
+
+
+def curl(url: str) -> str:
+    proc = subprocess.run(
+        ["curl", "-sS", url],
+        stdout=subprocess.PIPE,
+        check=True,
+        text=True,
+    )
+    return proc.stdout
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download_hs_queries.py
+++ b/scripts/download_hs_queries.py
@@ -65,16 +65,6 @@ def update_highlights(s: str) -> str:
         # instead of just normal built-in functions
         .replace("@keyword.exception", "@constant.builtin")
         .replace("@keyword.debug", "@constant.builtin")
-        # @_name is used in some signature highlighting for a local capture,
-        # which overrides the relevant highlighting
-        # We also need to add some arbitrary suffix to avoid clobbering the
-        # scope for (#eq? ...)
-        .replace(sig1, sig1.replace("@_name", "@_name @variable.x"))
-        .replace(sig2, sig2.replace("@_name", "@_name @function.x"))
-        .replace(sig3, sig3.replace("@_name", "@_name @function.x"))
-        # @_op is used as a local capture for predicates, but Zed will actually
-        # override the @operator capture previously set on (operator) nodes.
-        .replace("@_op", "@operator")
         # @spell isn't valid in Zed and overrides the @comment capture. Comment out
         # this line.
         .replace("(comment) @spell", ";(comment) @spell")


### PR DESCRIPTION
Previous commit was from Feb 14 2024. Updating to 0.23.1 from Nov 10 2024. Still old, but a bit newer. Specifically, looks like they did a complete overhaul in May 2024: https://github.com/tree-sitter/tree-sitter-haskell/commit/f8e8da7f1ee26c97160036355223c745e34fc6be

Unable to test this; installing as a Zed extension is failing with "Error: Failed to install dev extension: failed to compile grammar 'haskell'", and the zed logs isn't showing anything...